### PR TITLE
Remove TimeLimitedPaginator since not DB agnostic

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,2 @@
 [bandit]
-exclude:
-  - /tests
-  - server.py
+exclude: "/tests, server.py"

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,4 @@
+[bandit]
+exclude:
+  - /tests
+  - server.py

--- a/.bandit
+++ b/.bandit
@@ -1,1 +1,2 @@
-exclude: /tests
+[bandit]
+exclude: /tests,server.py

--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: /tests,server.py
+exclude: /tests,./server.py

--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,1 @@
-[bandit]
-exclude: "/tests, server.py"
+exclude: /tests

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
                          flake8-comprehensions isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B701 .
+      - run: bandit --recursive .
       - run: black --check .
       - run: codespell --ignore-words-list="nd"  # --skip="*.css,*.js,*.lock"
       - run: flake8 --ignore=F401 --max-complexity=15 --max-line-length=138 --show-source --statistics .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -2,6 +2,14 @@ name: lint_python
 on: [pull_request, push]
 jobs:
   lint_python:
+    # IF copied from https://github.com/psf/black/blob/main/.github/workflows/lint.yml:
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. Without this if check, checks are duplicated since
+    # internal PRs match both the push and pull_request events.
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -19,7 +19,7 @@ jobs:
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
                          flake8-comprehensions isort mypy pytest pyupgrade safety
-      - run: bandit .
+      - run: bandit --recursive .
       - run: black --check .
       - run: codespell --ignore-words-list="nd"  # --skip="*.css,*.js,*.lock"
       - run: flake8 --ignore=F401 --max-complexity=15 --max-line-length=138 --show-source --statistics .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
                          flake8-comprehensions isort mypy pytest pyupgrade safety
-      - run: bandit --recursive .
+      - run: bandit .
       - run: black --check .
       - run: codespell --ignore-words-list="nd"  # --skip="*.css,*.js,*.lock"
       - run: flake8 --ignore=F401 --max-complexity=15 --max-line-length=138 --show-source --statistics .

--- a/ark/admin.py
+++ b/ark/admin.py
@@ -1,54 +1,46 @@
+"""Django Admin models for Arklet."""
+
 from django.contrib import admin
-from django.core.paginator import Paginator
-from django.db import OperationalError, connection, transaction
-from django.utils.functional import cached_property
 
 from ark.models import Ark, Key, Naan, Shoulder, User
 
 
-class TimeLimitedPaginator(Paginator):
-    """
-    Paginator that enforces a timeout on the count operation.
-    If the operations times out, a fake bogus value is
-    returned instead.
-
-    Lifted from: https://web.archive.org/web/20210422225156/https://hakibenita.com/optimizing-the-django-admin-paginator
-    """
-
-    @cached_property
-    def count(self):
-        # We set the timeout in a db transaction to prevent it from
-        # affecting other transactions.
-        with transaction.atomic(), connection.cursor() as cursor:
-            cursor.execute("SET LOCAL statement_timeout TO 1000;")
-            try:
-                return super().count
-            except OperationalError:
-                return 9999999999
-
-
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
-    pass
+    """Django Admin model for ARK admin users."""
 
 
 @admin.register(Naan)
 class NaanAdmin(admin.ModelAdmin):
+    """Django Admin model for Name Assignment Authority Number bearing organizations."""
+
     list_display = ["name", "naan"]
 
 
 @admin.register(Shoulder)
 class ShoulderAdmin(admin.ModelAdmin):
+    """Django Admin model for ARK shoulders."""
+
     list_display = ["shoulder", "name", "naan"]
 
 
 @admin.register(Ark)
 class ArkAdmin(admin.ModelAdmin):
+    """Django Admin model for ARKs.
+
+    In practice, stock Django Admin doesn't work well for large randomly sorted tables.
+    This view will tend to take a long time to load as a full table count query is run.
+    """
+
     list_display = ["ark", "url"]
     show_full_result_count = False
-    paginator = TimeLimitedPaginator
 
 
 @admin.register(Key)
 class KeyAdmin(admin.ModelAdmin):
+    """Django Admin model for managing Arklet access keys.
+
+    These access keys are used to mint and bind ARKs via the Arklet API.
+    """
+
     list_display = ["key", "naan", "active"]

--- a/ark/management/commands/mintarks.py
+++ b/ark/management/commands/mintarks.py
@@ -12,6 +12,7 @@ from ark.utils import generate_noid
 
 class Command(BaseCommand):
     """Mint ark_count ARKs for the given naan and shoulder."""
+
     help = "Mint ARKs in bulk"
 
     def add_arguments(self, parser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ load-plugins = ["pylint_django", "pylint_pytest"]
 django-settings-module = "arklet.settings"
 
 [tool.pylint.basic]
-# Good variable names whic≠h should always be accepted, separated by a comma.
+# Good variable names which should always be accepted, separated by a comma.
 good-names = ["i", "j", "k", "e", "ex", "Run", "_", "rf", "pk", "db"]
 
 [build-system]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
-# Match black line length
-max-line-length = 88
+# Black won't auto-format away long strings but flake8 will still complain
+max-line-length = 138
 # W503: Line break occurred before a binary operator
 # E203: See https://github.com/PyCQA/pycodestyle/issues/373
 ignore = E203, W503


### PR DESCRIPTION
TimeLimitedPaginator was used to make the ArkAdmin model load more
quickly in Django Admin for large ARK tables. However, it uses a hack
specific to Postgres. I removed it (it didn't make the admin very
useful anyway) in favor of making Arklet DB agnostic.